### PR TITLE
Fixed the grunt file, so that when build is executed then bower compo…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -175,7 +175,7 @@ module.exports = function (grunt) {
         src: [
           '<%= yeoman.dist %>/scripts/{,*/}*.js',
           '<%= yeoman.dist %>/styles/{,*/}*.css',
-          '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
+          //'<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
           '<%= yeoman.dist %>/styles/fonts/*'
         ]
       }
@@ -317,6 +317,11 @@ module.exports = function (grunt) {
           cwd: '.tmp/images',
           dest: '<%= yeoman.dist %>/images',
           src: ['generated/*']
+        },{
+          cwd: 'bower_components',
+          dest: '<%= yeoman.dist %>/bower_components',
+          src: '**/*',
+          expand: true
         }]
       },
       styles: {


### PR DESCRIPTION
…nents are copied over and images are not renamed. Currently, the whole folder structure is copied over, since some of the components lack a main property in their bower.json. In the future get wiredep to work correctly.