### PR TITLE
Reqbaz signin

### DIFF
--- a/app/elements/requirements-list/requirements-list.html
+++ b/app/elements/requirements-list/requirements-list.html
@@ -77,6 +77,8 @@
             }
         </style>
 
+        <openidconnect-signin-aware is-authorized="{{isAuthorized}}"></openidconnect-signin-aware>
+
         <iron-ajax
                 id="requirementsLoader"
                 url="{{resourceURL}}"
@@ -105,10 +107,12 @@
                         <iron-collapse>
                             <h3>Comments</h3>
                             <comments-list requirement-id="[[item.id]]"></comments-list>
-                            <div class="container flex-horizontal" id="[[item.id]]">
-                                <paper-input id="[[item.id]]input" is="iron-input" on-input="showButton" label="Add a comment..." bind-value="{{newComment}}" class="flexchild"></paper-input>
-                                <paper-fab id="[[item.id]]fab" mini icon="send" class="flex-end-align" on-tap="addComment"></paper-fab>
-                            </div>
+                            <template is="dom-if" if="{{isAuthorized}}">
+                                <div class="container flex-horizontal" id="[[item.id]]">
+                                    <paper-input id="[[item.id]]input" is="iron-input" on-input="showButton" label="Add a comment..." bind-value="{{newComment}}" class="flexchild"></paper-input>
+                                    <paper-fab id="[[item.id]]fab" mini icon="send" class="flex-end-align" on-tap="addComment"></paper-fab>
+                                </div>
+                            </template>
                         </iron-collapse>
 
                     </div>
@@ -140,7 +144,8 @@
                     },
                     newComment: {
                         type: String
-                    }
+                    },
+                    isAuthorized: Boolean
                 },
 
                 ready: function () {

--- a/app/index.html
+++ b/app/index.html
@@ -63,6 +63,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <span id="browser-sync-binding"></span>
 <template is="dom-bind" id="app">
 
+    <openidconnect-signin-aware is-authorized="{{isAuthorized}}"></openidconnect-signin-aware>
+
     <!-- Main Area -->
     <paper-scroll-header-panel fixed>
 
@@ -290,7 +292,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                                 </div>
                             </paper-dialog>
 
-                            <paper-fab on-tap="onCreateRequirementTap" icon="add"></paper-fab>
+                            <template is="dom-if" if="{{isAuthorized}}">
+                                <paper-fab on-tap="onCreateRequirementTap" icon="add"></paper-fab>
+                            </template>
 
                         </paper-scroll-header-panel>
 

--- a/app/index.html
+++ b/app/index.html
@@ -79,12 +79,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <span class="flex"></span>
 
             <!-- Toolbar icons -->
-            <openidconnect-signin scopes="openid profile" client-id="a4b3f15a-eaec-489a-af08-1dc9cf57347e"
-                                  server="https://api.learning-layers.eu/o/oauth2" on-openidconnect-success="handleSigninSuccess"></openidconnect-signin>
             <a href="/projects">
                 <paper-icon-button id="paperToggle" icon="icons:visibility"></paper-icon-button>
             </a>
             <paper-icon-button icon="social:notifications" onclick="{{toggNotDrawer}}"></paper-icon-button>
+            <openidconnect-signin scopes="openid profile" client-id="a4b3f15a-eaec-489a-af08-1dc9cf57347e"
+                                  server="https://api.learning-layers.eu/o/oauth2" on-openidconnect-success="handleSigninSuccess"></openidconnect-signin>
             <!--<paper-icon-button icon="search"></paper-icon-button>-->
 
             <!-- Application name -->

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -15,6 +15,13 @@
     // Learn more about auto-binding templates at http://goo.gl/Dx1u2g
     var app = document.querySelector('#app');
 
+    /**
+     * Whether the user is logged in to the OIDC server.
+     *
+     * @type {boolean}
+     */
+    app.isAuthorized = false;
+
     app.displayInstalledToast = function() {
         // Check to make sure caching is actually enabled—it won't be in the dev environment.
         if (!document.querySelector('platinum-sw-cache').disabled) {


### PR DESCRIPTION
Added isAuthorized behavior. Note, that there is a top-level app.isAuthorized that is switched with its own openidconnect-signin-aware and then there's also an isAuthorized in the requirements-list element. Of course, I could have simply passed through the isAuthorized. But this way, we do not require 3rd parties who want to use a specific sub-element of ours to change the isAuthorized variable. Also, a major flaw (currently not of big interest) is that an openidconnect-signin-aware is only valid for a specific server. For example, in a strange case, an application could be logged in at different OIDC providers. Then, we would need to make sure to which one the comment box relates to.