### PR TITLE
fix: rename access_token header to access-token

### DIFF
--- a/src/api/bazaar.ts
+++ b/src/api/bazaar.ts
@@ -10,7 +10,7 @@ const getRequestHeaders = (user: User | null | undefined): RequestParams => {
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Basic ${window.btoa(`${user.profile.preferred_username}:${user.profile.sub}`)}`,
-      'access_token': user.access_token,
+      'access-token': user.access_token,
       'oidc_provider': 'https://api.learning-layers.eu/o/oauth2',
     },
     redirect: 'follow',


### PR DESCRIPTION
The wrong header name caused the backend not being able to read the access token, and thus las2peer could not create a new agent for new users.
This prevented new users from the using the Requirements Bazaar in any way.