### PR TITLE
Implement shareable requirement link

### DIFF
--- a/src/components/RequirementCard.vue
+++ b/src/components/RequirementCard.vue
@@ -50,6 +50,8 @@ import { ActionTypes } from '../store/actions';
 import { useConfirm } from "primevue/useconfirm";
 import CommentsList from './CommentsList.vue';
 
+import { routePathToRequirement } from '@/router';
+
 import RequirementEditor from '../components/RequirementEditor.vue';
 
 export default defineComponent({
@@ -74,7 +76,7 @@ export default defineComponent({
     brief: { type: Boolean, required: false, default: false },
   },
   setup: (props) => {
-    const { id, userVoted, isFollower, isDeveloper, realized, lastActivity, creationDate } = toRefs(props);
+    const { id, userVoted, isFollower, isDeveloper, realized, lastActivity, creationDate, categories, projectId } = toRefs(props);
     const { locale, t } = useI18n({ useScope: 'global' });
     const store = useStore();
     const confirm = useConfirm();
@@ -190,6 +192,11 @@ export default defineComponent({
       }
     )
 
+    const createShareableRequirementLink = () => {
+      const path = routePathToRequirement(projectId.value, id.value);
+      return window.location.origin + path;
+    }
+
     const shareMenu = ref(null);
     const toggleShareMenu = (event) => {
       (shareMenu as any).value.toggle(event);
@@ -221,7 +228,7 @@ export default defineComponent({
         icon: 'pi pi-copy',
         command: () => {
           console.log('Copying to clipboard...');
-          navigator.clipboard.writeText('');
+          navigator.clipboard.writeText(createShareableRequirementLink());
         },
       },
     ]);

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,7 @@ import Developer from './views/Developer.vue';
 import Projects from './views/Projects.vue';
 import Project from './views/Project.vue';
 import Category from './views/Category.vue';
+import Requirement from './views/Requirement.vue';
 import OidcCallback from './views/oidc/OidcCallback.vue';
 import OidcPopupCallback from './views/oidc/OidcPopupCallback.vue'
 import OidcCallbackError from './views/oidc/OidcCallbackError.vue'
@@ -88,8 +89,24 @@ export const router = createRouter({
       name: "category",
       component: Category,
     },
+    {
+      path: "/projects/:projectId/requirements/:requirementId",
+      name: "requirement",
+      component: Requirement,
+    },
   ],
 });
+
+export const routePathToProject = (projectId: string | number) => {
+  return `/projects/${projectId}`;
+};
+
+/**
+ * Returns the *route path* to the given requirment (no absolute URL!).
+ */
+export const routePathToRequirement = (projectId: string | number, requirementId: string | number) => {
+  return `/projects/${projectId}/requirements/${requirementId}`;
+};
 
 router.beforeEach(vuexOidcCreateRouterMiddleware(store, 'oidcStore'))
 router.beforeEach((to, from, next) => {

--- a/src/views/Requirement.vue
+++ b/src/views/Requirement.vue
@@ -1,0 +1,94 @@
+<template>
+  <ScrollTop />
+  <h1>{{ project?.name }}</h1>
+  <div id="description">
+    <vue3-markdown-it :source="project?.description" />
+  </div>
+  <div id="content">
+    <div v-if="requirement">
+      <RequirementCard
+        :id="requirement.id"
+        :projectId="requirement.projectId"
+        :categories="requirement.categories"
+        :name="requirement.name"
+        :description="requirement.description"
+        :upVotes="requirement.upVotes"
+        :numberOfComments="requirement.numberOfComments"
+        :numberOfFollowers="requirement.numberOfFollowers"
+        :creator="requirement.creator"
+        :creationDate="requirement.creationDate"
+        :lastActivity="requirement.lastActivity"
+        :userVoted="requirement.userContext.userVoted"
+        :isFollower="requirement.userContext.isFollower ? true : false"
+        :isDeveloper="requirement.userContext.isDeveloper ? true : false"
+        :realized="requirement.realized">
+      </RequirementCard>
+    </div>
+    <div v-else>
+        Requirement not found...
+    </div>
+    <div class="p-m-4 p-d-flex p-jc-center">
+        <Button
+            label="Show more Requirements"
+            @click="showMoreRequirements()" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, ref, watch } from 'vue';
+import { useStore } from 'vuex';
+import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { useConfirm } from 'primevue/useconfirm';
+
+import { ActionTypes } from '@/store/actions';
+import { routePathToProject } from '@/router';
+import RequirementCard from '@/components/RequirementCard.vue';
+
+export default defineComponent({
+  name: 'Requirement',
+  components: { RequirementCard },
+  props: {
+  },
+  setup: (props) => {
+    const store = useStore();
+    const route = useRoute();
+    const { t } = useI18n({ useScope: 'global' });
+    const oidcIsAuthenticated = computed(() => store.getters['oidcStore/oidcIsAuthenticated']);
+
+    const requirementId = Number.parseInt(route.params.requirementId.toString(), 10);
+    const projectId = Number.parseInt(route.params.projectId.toString(), 10);
+
+    const requirement = computed(() => store.getters.getRequirementById(requirementId));
+    const project = computed(() => store.getters.getProjectById(projectId));
+
+    store.dispatch(ActionTypes.FetchRequirement, requirementId);
+    store.dispatch(ActionTypes.FetchProject, projectId);
+
+    const { push } = useRouter();
+
+    const showMoreRequirements = () => {
+        push({path: routePathToProject(projectId)})
+    };
+
+    return {
+      t,
+      oidcIsAuthenticated,
+      project,
+      requirement,
+      showMoreRequirements,
+    }
+  }
+})
+</script>
+
+<style scoped>
+  #description {
+    margin-bottom: 2rem;
+  }
+
+  #content {
+    padding: 1rem;
+  }
+</style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,5 +17,10 @@ export default defineConfig({
     vueI18n({
       include: path.resolve(__dirname, './src/locales/**')
     })
-  ]
+  ],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'), // enables us to use import @/components etc. instead of using relative paths like ./../components
+    }
+  }
 })


### PR DESCRIPTION
Each requirement now has its own 'details' page. Currently, it shows only the project name, descriptions and includes the requirements card for the specific requirement. This page can get a lot of extension in the future regarding comments, showing progress, people working on the requirement etc.

Links to this details page can now be shared using the 'Share' button on a requirement card.