### PR TITLE
Error message to user for uncaught errors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
     <div id="layout" :class="{ 'p-mr-3': !activityTrackerVisible }">
       <div id="container">
         <div id="content">
+          <GlobalErrorMessage></GlobalErrorMessage>
           <router-view></router-view>
           <ConfirmDialog group="dialog"></ConfirmDialog>
           <ConfirmPopup group="popup"></ConfirmPopup>
@@ -22,13 +23,15 @@
 import { defineComponent, ref, watch } from 'vue'
 import AppTopbar from './components/AppTopbar.vue';
 import ActivityTracker from './components/ActivityTracker.vue';
+import GlobalErrorMessage from './components/GlobalErrorMessage.vue';
 import { useI18n } from 'vue-i18n';
 
 export default defineComponent({
   name: 'App',
   components: {
     AppTopbar,
-    ActivityTracker
+    ActivityTracker,
+    GlobalErrorMessage
   },
   setup: () => {
     const { locale } = useI18n({ useScope: 'global' });

--- a/src/components/GlobalErrorMessage.vue
+++ b/src/components/GlobalErrorMessage.vue
@@ -1,0 +1,28 @@
+<template>
+    <Message v-for="error in uncoughtErrors" :key="error.timestamp" severity="error" :closable="true">
+      <div>
+        <div>{{error.message}}</div>
+        <div style="font-size: 0.8rem"><i>Source: {{error.source}}</i></div>
+      </div>
+    </Message>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from 'vue';
+import { useStore } from 'vuex';
+import { useI18n } from 'vue-i18n';
+
+export default defineComponent({
+  name: 'GlobalErrorMessage',
+  setup: () => {
+    const { locale, t } = useI18n({ useScope: 'global' });
+    const store = useStore();
+
+    const uncoughtErrors = computed(() => store.getters.unhandledErrors());
+
+    return {
+      uncoughtErrors
+    };
+  },
+})
+</script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,12 +39,14 @@ import Skeleton from 'primevue/skeleton';
 import TabMenu from 'primevue/tabmenu';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
+import Message from 'primevue/message';
 
 import 'primevue/resources/themes/saga-green/theme.css';
 import 'primevue/resources/primevue.min.css';
 import 'primeflex/primeflex.css';
 import 'primeicons/primeicons.css';
 import './assets/layout/layout.scss';
+import ErrorHandler from './service/ErrorHandler';
 
 const app = createApp(App);
 const i18n = createI18n({
@@ -63,6 +65,32 @@ app.use(PrimeVue);
 app.use(i18n);
 app.use(VueMarkdownIt);
 app.config.globalProperties.$dayjs = dayjs;
+
+app.config.errorHandler = (err, vm, info) => {
+  console.log('[DEBUG] Vue error handler called: ');
+  console.log(err);
+  ErrorHandler.onError(err);
+}
+
+/**
+ * Catch unhandler errors from Promises and process by ErrorHandler.
+ *
+ * Error handler might detect e.g., a Bazaar API error response and show
+ * a (localized) useful message to the user.
+ */
+ window.addEventListener('unhandledrejection', event => {
+  if (event.reason) {
+    if (event.reason.ignoreUnhandledRejection) {
+      console.log('unhandledrejection seems to be already handled')
+      event.preventDefault();
+    }
+    const handled = ErrorHandler.onError(event.reason);
+    if (handled) {
+      console.log('handled unhandledrejection event by ErrorHandler')
+      event.preventDefault();
+    }
+  }
+});
 
 app.directive('badge', BadgeDirective);
 
@@ -84,5 +112,6 @@ app.component('Skeleton', Skeleton);
 app.component('TabMenu', TabMenu);
 app.component('TabView', TabView);
 app.component('TabPanel', TabPanel);
+app.component('Message', Message);
 
 app.mount('#app');

--- a/src/service/ErrorHandler.ts
+++ b/src/service/ErrorHandler.ts
@@ -1,0 +1,70 @@
+import { store } from './../store';
+import { MutationType } from './../store/mutations';
+import { UnhandledError } from './../store/state';
+
+/**
+ * Can be used either directly from code or in global error hadling functions (see main.ts for our global Promise error handler).
+ *
+ * If you know the type of error (HTTP error, or more specific Bazaar API error) call the more specialized function. Otherwise,
+ * use 'onError(error)' which tries to detect the error type and take appropriate actions.
+ *
+ * This handler tries to get the bes error information (maybe even a localized message from an API) out of the error and
+ * stores it in the global application state. The 'GlobalErrorMessage' will then displays a nice error message to the user.
+ */
+export default class ErrorHandler {
+
+    static onError(error): boolean {
+        console.log('[DEBUG] Handling error...');
+        if (error.status && error.error && error.headers) {
+            // chances are high we ahve an uncought fetch error response object
+            const handled = this.onHttpError(error);
+            if (handled) {
+                this._markHandled(error);
+            }
+            return handled;
+        }
+
+        console.log('[DEBUG] Undetected error type. Logging as error again...')
+        console.error(error);
+        // return false so caller can properly handle if necesarry
+        return false;
+    }
+
+    static onHttpError(response) {
+        console.log('[DEBUG] Handling HTTP error');
+        // response.error might have common properties from Requirements Bazaar API
+        const errorData = response.error;
+        if (errorData.errorCode && errorData.message && errorData.localizedMessage) {
+            // error response is likely in the common API format
+            this.onBazaarApiError(response);
+        } else {
+            // common HTTP error
+            this._storeError({
+                message: `Unexpected HTTP error (status code: ${response.status}`,
+                source: 'HTTP Request',
+                details: `HTTP status: ${response.status}; data:` + response.error.toString(),
+                timestamp: Date.now(),
+            });
+        }
+        return true;
+    }
+
+    static onBazaarApiError(response) {
+        console.log('[DEBUG] Handling Bazaar API error');
+
+        this._storeError({
+            message: response.error.localizedMessage,
+            source: 'Requirements Bazaar API',
+            details: `HTTP status: ${response.status}; data:` + response.error.toString(),
+            timestamp: Date.now(),
+        });
+    }
+
+    static _storeError(error: UnhandledError) {
+        store.commit(MutationType._AddUnhandledError, error);
+    }
+
+    static _markHandled(error) {
+        error.ignoreUnhandledRejection = true;
+    }
+}

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -1,5 +1,5 @@
 import { GetterTree } from 'vuex'
-import { State } from './state'
+import { State, UnhandledError } from './state'
 import { Project, Category, Requirement, Comment } from '../types/bazaar-api';
 import { Activity } from '../types/activities-api';
 
@@ -12,6 +12,7 @@ export type Getters = {
   getRequirementById(state: State): (id: number) => Requirement | undefined;
   commentsList(state: State): (requirementId: number) => Comment[];
   activitiesList(state: State): (parameters: any) => Activity[];
+  unhandledErrors(state: State): (parameters: any) => UnhandledError[];
 }
 
 const numericalSortFunction = (property, sortAscending) => (a, b) => {
@@ -180,6 +181,11 @@ export const getters: GetterTree<State, State> & Getters = {
     activities.sort(numericalSortFunction('id', false));
 
     return activities.slice(0, parameters.limit);
+  },
+
+  unhandledErrors: (state: State) => (parameters: any) => {
+
+    return state.unhandledErrors;
   },
 
 }

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -1,5 +1,5 @@
 import { MutationTree } from 'vuex'
-import { State, LocalComment } from './state'
+import { State, LocalComment, UnhandledError } from './state'
 
 import { Project, Category, Requirement, Comment, Dashboard } from '../types/bazaar-api';
 import { Activity } from '../types/activities-api';
@@ -26,6 +26,8 @@ export enum MutationType {
   SetDashboard = 'SET_DASHBOARD',
 
   SetActivities = 'SET_ACTIVITIES',
+
+  _AddUnhandledError = 'ADD_UNHANDLED_ERROR',
 }
 
 export type Mutations = {
@@ -51,6 +53,8 @@ export type Mutations = {
 
 
   [MutationType.SetActivities](state: State, activities: Activity[]): void;
+
+  [MutationType._AddUnhandledError](state: State, error: UnhandledError): void;
 };
 
 export const mutations: MutationTree<State> & Mutations = {
@@ -205,4 +209,7 @@ export const mutations: MutationTree<State> & Mutations = {
     });
   },
 
+  [MutationType._AddUnhandledError](state, error) {
+    state.unhandledErrors.push(error);
+  },
 }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -6,6 +6,13 @@ export interface LocalComment extends Comment {
   draftMessage?: String;
 }
 
+export interface UnhandledError {
+  message: string;
+  source: string;
+  details: string;
+  timestamp: number;
+}
+
 export type State = {
   projects: {[id: number]: Project};
   categories: {[id: number]: Category};
@@ -13,6 +20,7 @@ export type State = {
   comments: {[id: number]: LocalComment};
   activities: {[id: number]: Activity};
   dashboard: Dashboard;
+  unhandledErrors: UnhandledError[];
 }
 
 export const state: State = {
@@ -26,4 +34,5 @@ export const state: State = {
     categories: [],
     requirements: [],
   },
+  unhandledErrors: [],
 };


### PR DESCRIPTION
This feature should be the fallback option in case the application code does not handle errors in the concrete situations, like it's done everywhere currently. To improve user experience, we should show errors in some other places (e.g. if there is a dialog opened, the error should be shown directly in the dialog)