### PR TITLE
Show user profile or default icon in activity tracker and comments

### DIFF
--- a/src/components/ActivityTracker.vue
+++ b/src/components/ActivityTracker.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="activitiesList">
     <div v-for="activity in activities" :key="activity.id" class="activity">
-      <Avatar :image="activity.user.profileImage" shape="circle" size="large" class="profileImage"/>
+      <UserAvatar :imageUrl="activity.user.profileImage" :userName="activity.user.userName" class="profileImage" />
+
       <div class="activityText">
         {{ activity.user.userName }}
         {{ actionWordings[activity.activityAction] }}
@@ -15,8 +16,10 @@
 import { computed, defineComponent } from 'vue';
 import { useStore } from 'vuex';
 import { ActionTypes } from '../store/actions';
+import UserAvatar from './UserAvatar.vue';
 
 export default defineComponent({
+  components: { UserAvatar },
   name: 'ActivityTracker',
   props: {
   },
@@ -87,7 +90,7 @@ export default defineComponent({
   }
 
   .profileImage {
-    margin: auto 0;
+    margin: auto 5px;
   }
 
   .activity ::v-deep(.p-avatar > img) {

--- a/src/components/CommentsList.vue
+++ b/src/components/CommentsList.vue
@@ -10,8 +10,9 @@
     <div>
       <div v-for="comment in comments" :key="comment.id" class="comment p-mb-3">
         <div class="p-d-flex p-mb-1" :class="{ reply: comment.replyToComment }">
-            <Skeleton shape="circle" size="2.5rem" class="p-mr-2"></Skeleton>
-            <div>
+            <!-- NOTE: creator attribute may be null (e.g., when comment was deleted) -->
+            <UserAvatar :imageUrl="comment.creator?.profileImage" :userName="comment.creator?.userName" size="small" />
+            <div class="p-pl-2">
                 <div>{{ comment.deleted ? t('deletedCommented') : comment.message }}</div>
                 <div class="info">
                   <span v-if="oidcIsAuthenticated && !comment.deleted">
@@ -48,12 +49,14 @@ import { ActionTypes } from '../store/actions';
 import { MutationType } from '../store/mutations';
 import { Comment } from '../types/bazaar-api';
 import { LocalComment } from '../store/state';
+import UserAvatar from './UserAvatar.vue';
 
 export default defineComponent({
   name: 'RequirementCard',
   props: {
     requirementId: { type: Number, required: true },
   },
+  components: { UserAvatar },
   setup: ({ requirementId }) => {
     const store = useStore();
     const { t } = useI18n({ useScope: 'global' });
@@ -96,7 +99,7 @@ export default defineComponent({
           requirementId,
         };
       }
-      
+
       store.dispatch(ActionTypes.CreateComment, comment);
     };
 

--- a/src/components/ProjectMembersList.vue
+++ b/src/components/ProjectMembersList.vue
@@ -8,15 +8,8 @@
             sortMode="single" sortField="role" :sortOrder="1" scrollable scrollHeight="800px">
             <Column field="userName" header="User">
                 <template #body="slotProps">
-                    <!-- Shows a default icon if profile image loading fails (currently always the case!) -->
-                    <i v-if="showDefaultUserIcon[slotProps.data.userId] === true"
-                        class="pi pi-user p-pr-3" style="fontSize: 1rem; vertical-align: middle;"></i>
-                    <img v-else
-                        :alt="slotProps.data.userName"
-                        :src="slotProps.data.userProfileImage"
-                        @error="handleUserImageError(slotProps.data.userId)"
-                        width="32" style="vertical-align: middle" class="p-pr-3" />
-                    <span class="image-text">{{slotProps.data.userName}}</span>
+                    <UserAvatar :imageUrl="slotProps.data.userProfileImage" :userName="slotProps.data.userName" size="small" />
+                    <span class="image-text p-pl-2">{{slotProps.data.userName}}</span>
                 </template>
             </Column>
             <Column field="userId" header="User ID"></Column>
@@ -121,11 +114,14 @@ import { ActionTypes } from '../store/actions';
 import { ProjectMember, User } from '../types/bazaar-api';
 import { bazaarApi, ProjectMemberRole } from '../api/bazaar';
 
+import UserAvatar from './UserAvatar.vue';
+
 export default defineComponent({
   name: 'ProjectMembersList',
   props: {
     projectId: { type: Number, required: true },
   },
+  components: { UserAvatar },
   setup: ({ projectId }) => {
     const store = useStore();
     const { t } = useI18n({ useScope: 'global' });

--- a/src/components/UserAvatar.vue
+++ b/src/components/UserAvatar.vue
@@ -1,7 +1,7 @@
 <template>
-    <Avatar v-if="showDefaultIcon" icon="pi pi-user" shape="circle" size="large">
-    </Avatar>
-    <Avatar v-else shape="circle" size="large" label="bar">
+    <Avatar v-if="showDefaultIcon" icon="pi pi-user" shape="circle" :size="size"
+            v-bind:class="[ { 'p-avatar-sm': size === 'small' } ]" />
+    <Avatar v-else shape="circle" :size="size" v-bind:class="[ { 'p-avatar-sm': size === 'small' } ]">
         <img :alt="userName" :src="imageUrl" @error="handleImageError()" />
     </Avatar>
 </template>
@@ -14,13 +14,12 @@ export default defineComponent({
   props: {
       imageUrl: { type: String, required: true },
       userName: { type: String, required: true },
+      size: { type: String, default: 'large' },
   },
   setup: () => {
-
     const showDefaultIcon = ref(false);
 
     const handleImageError = () => {
-        console.log("image loading error");
         showDefaultIcon.value = true;
     };
 
@@ -29,3 +28,11 @@ export default defineComponent({
 
 })
 </script>
+
+<style scoped>
+    .p-avatar-sm {
+        width: 2rem;
+        height: 2rem;
+        font-size: 1.3rem;
+    }
+</style>

--- a/src/components/UserAvatar.vue
+++ b/src/components/UserAvatar.vue
@@ -12,12 +12,13 @@ import { defineComponent, ref } from 'vue';
 export default defineComponent({
   name: 'UserAvatar',
   props: {
-      imageUrl: { type: String, required: true },
-      userName: { type: String, required: true },
+      imageUrl: { type: String, required: false },
+      userName: { type: String, default: 'anonymous' },
       size: { type: String, default: 'large' },
   },
-  setup: () => {
-    const showDefaultIcon = ref(false);
+  setup: (props) => {
+    // show default icon if no image URL is given (e.g., in case of a deleted user)
+    const showDefaultIcon = ref(props.imageUrl === undefined);
 
     const handleImageError = () => {
         showDefaultIcon.value = true;

--- a/src/components/UserAvatar.vue
+++ b/src/components/UserAvatar.vue
@@ -1,0 +1,31 @@
+<template>
+    <Avatar v-if="showDefaultIcon" icon="pi pi-user" shape="circle" size="large">
+    </Avatar>
+    <Avatar v-else shape="circle" size="large" label="bar">
+        <img :alt="userName" :src="imageUrl" @error="handleImageError()" />
+    </Avatar>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  name: 'UserAvatar',
+  props: {
+      imageUrl: { type: String, required: true },
+      userName: { type: String, required: true },
+  },
+  setup: () => {
+
+    const showDefaultIcon = ref(false);
+
+    const handleImageError = () => {
+        console.log("image loading error");
+        showDefaultIcon.value = true;
+    };
+
+    return { showDefaultIcon, handleImageError };
+  },
+
+})
+</script>


### PR DESCRIPTION
Added a new `UserAvatar` component which either shows a user's profile image, or a default icon in case of a loading error.

Can be reused at different locations (currently: activity tracker, comments, project member list)