### PR TITLE
Fix/development timeline UI

### DIFF
--- a/src/components/RequirementCard.vue
+++ b/src/components/RequirementCard.vue
@@ -251,11 +251,34 @@ export default defineComponent({
       displayRequirementEditor.value = false;
     }
 
+    const createGitHubIssueForRequirement = () => {
+      const githubBaseUrl = project.value.additionalProperties.github_url;
+      const requirementTitle = name.value.replace(/\s/g, '+');
+      const requirementDescription = description.value.replace(/\s/g, '+');
+      const bazaarRequirementUrl = createShareableRequirementLink()
+      if(additionalPropertiesValue == undefined){
+        confirm.require({
+          header: 'Create Issue for Requirement',
+          message: 'You will be redirected to GitHub',
+          icon: 'pi pi-external-link',
+          group: 'dialog',
+            accept: () => {
+        window.open(githubBaseUrl+"/issues/new?"+"title="+requirementTitle+"&body="+requirementDescription+" -> _**See+requirement+in+Bazaar:**_ "+bazaarRequirementUrl);
+        },
+            reject: () => {
+        console.log('not redirected');
+        }
+      });
+      }else{
+        alertShareGitHub('This Requirement is already on GitHub.')
+      }
+    };
+
     const menuItems = ref();
     // watch multiple props
     watch(
-      [locale, isFollower, isDeveloper, realized],
-      ([_, isFollower, isDeveloper, realized]) => {
+      [locale, isFollower, isDeveloper, realized, issue_url, github_url],
+      ([_, isFollower, isDeveloper, realized, issue_url, github_url]) => {
         menuItems.value = [
           {
             label: isFollower ? t('unfollowRequirement') : t('followRequirement'),
@@ -283,6 +306,18 @@ export default defineComponent({
             icon: 'pi pi-pencil',
             command: () => {
               displayRequirementEditor.value = true;
+            }
+          },
+          {
+            label: issue_url ? t('viewOnGitHub') : t('createGithubIssue'),
+            icon: 'pi pi-github',
+            disabled: github_url === undefined,
+            command: () => {
+              if (issue_url) {
+                window.open(issue_url)
+              } else {
+                createGitHubIssueForRequirement();
+              }
             }
           },
           {
@@ -320,26 +355,7 @@ export default defineComponent({
         label: 'GitHub',
         icon: 'pi pi-github',
         command: () => {
-          const githubBaseUrl = project.value.additionalProperties.github_url;
-          const requirementTitle = name.value.replace(/\s/g, '+');
-          const requirementDescription = description.value.replace(/\s/g, '+');
-          const bazaarRequirementUrl = createShareableRequirementLink()
-          if(additionalPropertiesValue == undefined){
-            confirm.require({
-              header: 'Share to GitHub',
-              message: 'You will be redirected to GitHub',
-              icon: 'pi pi-external-link',
-              group: 'dialog',
-                accept: () => {
-            window.open(githubBaseUrl+"/issues/new?"+"title="+requirementTitle+"&body="+requirementDescription+" -> _**See+requirement+in+Bazaar:**_ "+bazaarRequirementUrl);
-            },
-                reject: () => {
-            console.log('not redirected');
-            }
-          });
-          }else{
-            alertShareGitHub('This Requirement is already on GitHub.')
-          }
+          createGitHubIssueForRequirement();
         },
       },
       {

--- a/src/components/RequirementCard.vue
+++ b/src/components/RequirementCard.vue
@@ -19,20 +19,22 @@
     <template #content>
     <vue3-markdown-it :source="description" class="p-mt-3 p-mb-3" />
     <!-- Timeline -->
-    <div class="p-d-flex p-jc-start p-ai-center">
-      <h2>Development Timeline</h2>
-      <a v-if="issue_url" :href="issue_url" target="_blank" rel="noreferrer" class="p-ml-2"><i class="pi pi-github"></i> View on GitHub</a>
+    <div v-if="issue_url">
+      <div class="p-d-flex p-jc-start p-ai-center">
+        <h2>Development Timeline</h2>
+        <a v-if="issue_url" :href="issue_url" target="_blank" rel="noreferrer" class="p-ml-2"><i class="pi pi-github"></i> View on GitHub</a>
+      </div>
+      <Timeline :value="timelineEvents" layout="horizontal" align="bottom">
+          <template #marker="slotProps">
+            <span class="custom-marker">
+              <i :class="slotProps.item.status"></i>
+            </span>
+          </template>
+          <template #content="slotProps">
+            {{slotProps.item.label}}
+          </template>
+      </Timeline>
     </div>
-    <Timeline :value="timelineEvents" layout="horizontal" align="bottom">
-        <template #marker="slotProps">
-          <span class="custom-marker">
-            <i :class="slotProps.item.status"></i>
-          </span>
-        </template>
-        <template #content="slotProps">
-          {{slotProps.item.label}}
-        </template>
-    </Timeline>
       <Dialog :header="t('editRequirement')" v-model:visible="displayRequirementEditor" :breakpoints="{'960px': '75vw', '640px': '100vw'}" :style="{width: '50vw'}" :modal="true">
         <RequirementEditor
           class="requirementEditor"

--- a/src/components/RequirementCard.vue
+++ b/src/components/RequirementCard.vue
@@ -8,10 +8,6 @@
             <div class="title">{{ name }}</div>
           </router-link>
         </div>
-
-        <div>
-          <Button icon="pi pi-github" label="See on GitHub" class="p-button-outlined" @click="checkRequirementOnGitHub" v-if="showButtonGitHub()"></Button>
-        </div>
       </div>
       <div class="lastupdate">
         <span :title="$dayjs(activityDate).format('LLL')">{{ $dayjs(activityDate).fromNow() }}</span>
@@ -23,7 +19,10 @@
     <template #content>
     <vue3-markdown-it :source="description" class="p-mt-3 p-mb-3" />
     <!-- Timeline -->
-    <h2>Development Timeline</h2>
+    <div class="p-d-flex p-jc-start p-ai-center">
+      <h2>Development Timeline</h2>
+      <a v-if="issue_url" :href="issue_url" target="_blank" rel="noreferrer" class="p-ml-2"><i class="pi pi-github"></i> View on GitHub</a>
+    </div>
     <Timeline :value="timelineEvents" layout="horizontal" align="bottom">
         <template #marker="slotProps">
           <span class="custom-marker">
@@ -130,6 +129,11 @@ export default defineComponent({
         return project.value.additionalProperties.github_url
       }
     });
+    const issue_url = computed(() => {
+      if (additionalProperties.value && additionalProperties.value.issue_url ) {
+        return additionalProperties.value.issue_url
+      }
+    });
 
     // get issue's additionalProperties Descriptors & Values
     const additionalPropertiesValue = additionalProperties.value;
@@ -137,15 +141,12 @@ export default defineComponent({
     if(additionalPropertiesValue === undefined || additionalPropertiesValue === null){
       var issueNumberValue = undefined;
       var issueStatusValue = undefined;
-      var issueUrlValue = undefined;
 
     }else{
           const issueNumberDescriptor = Object.getOwnPropertyDescriptor(additionalProperties.value, 'issue_number');
           issueNumberValue = issueNumberDescriptor?.value;
           const issueStatusDescriptor = Object.getOwnPropertyDescriptor(additionalProperties.value, 'issue_status');
           issueStatusValue = issueStatusDescriptor?.value;
-          const issueUrlDescriptor = Object.getOwnPropertyDescriptor(additionalProperties.value, 'issue_url');
-          issueUrlValue = issueUrlDescriptor?.value;
     }
 
     // **** Functions to update the timeline icons *****
@@ -172,7 +173,7 @@ export default defineComponent({
     // Requirement Url (Development in Progress)
     function timelineIssueUrl(){
       let timelineIssueUrlIcon = "pi pi-circle-off";
-      if(issueUrlValue != undefined){
+      if(issue_url.value != undefined){
         timelineIssueUrlIcon = "pi pi-check-circle";
       }
       return timelineIssueUrlIcon;
@@ -184,14 +185,6 @@ export default defineComponent({
       {label: 'Development in Progress', status: timelineIssueUrl()},
       {label: 'Closed',                  status: timelineIssueStatus()},
       ]);
-
-    // show button "check it on github"
-    function showButtonGitHub(){
-      let buttonCheckOnGitHub = false;
-      if(issueUrlValue != undefined)
-        buttonCheckOnGitHub = true;
-      return buttonCheckOnGitHub;
-    }
 
     const alertLogin = (message: string) => {
       confirm.require({
@@ -225,22 +218,6 @@ export default defineComponent({
       } else {
         alertLogin('You need to sign in to vote for a requirement.');
       }
-    };
-
-    // Redirect to github "see requirement btn"
-    const checkRequirementOnGitHub = () => {
-      confirm.require({
-        header: 'See this requirement on GitHub',
-        message: 'You will be redirected to GitHub',
-        icon: 'pi pi-external-link',
-        group: 'dialog',
-            accept: () => {
-            window.open(issueUrlValue);
-            },
-            reject: () => {
-            console.log('not redirected');
-            }
-      })
     };
 
     const menu = ref(null);
@@ -400,8 +377,7 @@ export default defineComponent({
       requirementEditorCanceled,
       requirementEditorSaved,
       timelineEvents,
-      checkRequirementOnGitHub,
-      showButtonGitHub,
+      issue_url,
     };
   },
 })

--- a/src/components/RequirementCard.vue
+++ b/src/components/RequirementCard.vue
@@ -347,20 +347,15 @@ export default defineComponent({
       {
         label: 'Facebook',
         icon: 'pi pi-facebook',
+        disabled: true,
         command: () => {
           console.log('Sharing to Facebook...');
         },
       },
       {
-        label: 'GitHub',
-        icon: 'pi pi-github',
-        command: () => {
-          createGitHubIssueForRequirement();
-        },
-      },
-      {
         label: 'Twitter',
         icon: 'pi pi-twitter',
+        disabled: true,
         command: () => {
           console.log('Sharing to Twitter...');
         },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -69,6 +69,8 @@
     "developRequirement": "Develop Requirement",
     "undevelopRequirement": "Undevelop Requirement",
     "editRequirement": "Edit Requirement",
+    "viewOnGitHub": "View on Github",
+    "createGithubIssue": "Create GitHub Issue",
     "creator": "Creator",
     "leadDeveloper": "Lead Developer",
     "comments": "Comments",

--- a/src/views/Project.vue
+++ b/src/views/Project.vue
@@ -8,7 +8,7 @@
   <div id="description">
     <vue3-markdown-it :source="project?.description" />
   </div>
-  <div id="timeline">
+  <div id="timeline" v-if="timelineEnabled">
     <h2>Development Timeline</h2>
     <Timeline :value="timelineEvents" layout="horizontal" align="bottom">
         <template #marker="slotProps">
@@ -20,7 +20,7 @@
           {{slotProps.item.label}}
         </template>
     </Timeline>
-    </div>
+  </div>
 
   <Dialog :header="t('editProject')" v-model:visible="displayProjectEditor" :breakpoints="{'960px': '75vw', '640px': '100vw'}" :style="{width: '50vw'}" :modal="true">
     <ProjectEditor
@@ -177,6 +177,12 @@ export default defineComponent({
     const release_value = computed(() => project.value?.additionalProperties?.release); //url
     const pull_request_status = computed(() => project.value?.additionalProperties?.pull_request); //status
     const pull_request_url = computed(() => project.value?.additionalProperties?.pull_request_url); //url
+
+    /*
+     * Temporary disable the timeline for projects until we have better semantics for it.
+     */
+    const timelineEnabled = ref(false);
+
     // ****** Functions to update the timeline icons *****
     // Project exported & hook received
     function timelineStatusGithub(){
@@ -555,6 +561,7 @@ export default defineComponent({
       webhookSecret,
       webhookSettingsOpened,
       openWebhookSettings,
+      timelineEnabled,
     }
   }
 })


### PR DESCRIPTION
Implements #175 and multiple smaller changes discussed in that context:

- fix: inline link to GitHub issue instead of oversized button
- fix: show development timeline only for requirements with linked issue #179
- fix: disable development timeline in project overview #175
- feat: add menu items to create and view GitHub issue for a requirement
- fix: remove GitHub from share button and disable Twitter and Facebook options