### PR TITLE
fix: migrate to new OIDC domain

### DIFF
--- a/src/api/bazaar.ts
+++ b/src/api/bazaar.ts
@@ -11,7 +11,7 @@ const getRequestHeaders = (user: User | null | undefined): RequestParams => {
       'Content-Type': 'application/json',
       'Authorization': `Basic ${window.btoa(`${user.profile.preferred_username}:${user.profile.sub}`)}`,
       'access-token': user.access_token,
-      'oidc_provider': 'https://api.learning-layers.eu/o/oauth2',
+      'oidc_provider': 'https://auth.las2peer.org/o/oauth2',
     },
     redirect: 'follow',
     referrerPolicy: 'no-referrer',

--- a/src/config/oidc.js
+++ b/src/config/oidc.js
@@ -1,5 +1,5 @@
 export const oidcSettings = {
-  authority: 'https://api.learning-layers.eu/o/oauth2',
+  authority: 'https://auth.las2peer.org/o/oauth2',
   clientId: 'c7588efc-f831-4e31-928e-0f46a91fb311',
   redirectUri: `${import.meta.env.VITE_OIDC_CALLBACK_URL}/oidc-callback`,
   popupRedirectUri: `${import.meta.env.VITE_OIDC_CALLBACK_URL}/oidc-popup-callback`,


### PR DESCRIPTION
Changed OIDC domain from `api.learning-layers.eu` to `auth.las2peer.org`

See internal documentation for more: https://moodle.tech4comp.dbis.rwth-aachen.de/mod/forum/discuss.php?d=1307#p3126