### PR TITLE
Fix/many login reloads

### DIFF
--- a/src/config/oidc.js
+++ b/src/config/oidc.js
@@ -7,4 +7,5 @@ export const oidcSettings = {
   scope: 'openid email profile',
   automaticSilentRenew: true,
   automaticSilentSignin: true,
+  monitorSession: false,
 };

--- a/src/views/oidc/OidcCallback.vue
+++ b/src/views/oidc/OidcCallback.vue
@@ -15,11 +15,13 @@ export default {
   created () {
     this.oidcSignInCallback()
       .then((redirectPath) => {
+        console.log('OIDC SingInCallback called with rediectPath: ' + redirectPath);
         this.$router.push(redirectPath)
       })
       .catch((err) => {
+        console.log('OIDC SingInCallback error caught:');
         console.error(err)
-        this.$router.push('/signin-oidc-error') // Handle errors any way you want
+        this.$router.push('/oidc-callback-error') // Handle errors any way you want
       })
   }
 }


### PR DESCRIPTION
Fixes:
- #142 

The fix disables the  'monitorSession' flag for OIDC configuration.
This seems to fix the many unintended page reloads which caused login errors to be printed in the console.

Also, this should reduce the memory footprint of the web application by at least 50%  because resources are not reloaded like 6-7 times in the background.

Fix recommended by https://stackoverflow.com/questions/61817737/silent-renew-infinite-looping-in-vue-application