### PR TITLE
Fix: progress indicator and 'no content' message fixes

### DIFF
--- a/src/components/CommentsList.vue
+++ b/src/components/CommentsList.vue
@@ -8,6 +8,9 @@
       </template>
     </Dialog>
     <div>
+      <div v-if="comments.length === 0">
+        <p>{{ t('noComments') }}</p>
+      </div>
       <div v-for="comment in comments" :key="comment.id" class="comment p-mb-3">
         <div class="p-d-flex p-mb-1" :class="{ reply: comment.replyToComment }">
             <!-- NOTE: creator attribute may be null (e.g., when comment was deleted) -->

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -144,6 +144,8 @@
     "delCommTitle": "Delete Comment",
     "delCommDesc": "This action can't be undone! Are you sure that you want to permanently delete this comment?",
     "noComments": "No comments yet…",
+    "noDevelopers": "No developers. Maybe you can develop this feature?",
+    "noFollowers": "No followers. Be the first one to follow the project!",
     "by": " by ",
     "deleteRequirement": "Delete Requirement",
     "deleteRequirementDesc": "This action can't be undone! Are you sure that you want to permanently delete this requirement?",

--- a/src/views/Requirement.vue
+++ b/src/views/Requirement.vue
@@ -67,6 +67,11 @@
                       <span class="image-text p-pl-2">{{slotProps.data.userName}}</span>
                   </template>
               </Column>
+              <template #empty>
+                <div class="empty-table-message">
+                  {{ t('noFollowers') }}
+                </div>
+              </template>
             </DataTable>
           </div>
         </div>
@@ -84,6 +89,11 @@
                       <span class="image-text p-pl-2">{{slotProps.data.userName}}</span>
                   </template>
               </Column>
+              <template #empty>
+                <div class="empty-table-message">
+                  {{ t('noDevelopers') }}
+                </div>
+              </template>
             </DataTable>
           </div>
         </div>
@@ -396,6 +406,11 @@ export default defineComponent({
   }
 
   .loading-container {
+    text-align: center;
+  }
+
+  .empty-table-message {
+    width: 100%;
     text-align: center;
   }
 

--- a/src/views/Requirement.vue
+++ b/src/views/Requirement.vue
@@ -8,6 +8,10 @@
     class="p-mt-3" />
 
   <div id="content">
+    <div v-if="loading" class="loading-container">
+      <ProgressSpinner />
+    </div>
+
     <div v-if="requirement">
       <div class="title">
         <Badge v-if="requirement.realized" value="Done" class="p-mr-2"></Badge><h1> {{ requirement.name }}</h1>
@@ -86,7 +90,7 @@
       </div>
     </div>
 
-    <div v-else>
+    <div v-if="requirement === undefined && !loading">
       <h1>{{ t('notFound') }}</h1>
       {{ t('requirementDetails-requirementNotFound') }}
     </div>
@@ -145,6 +149,7 @@ export default defineComponent({
     const projectId = Number.parseInt(route.params.projectId.toString(), 10);
     const activeTab = computed(() => route.params.activeTab);
 
+    const loading = ref(true);
     const requirement = computed(() => store.getters.getRequirementById(requirementId));
     const project = computed(() => store.getters.getProjectById(projectId));
 
@@ -177,7 +182,9 @@ export default defineComponent({
       }
     });
 
-    store.dispatch(ActionTypes.FetchRequirement, requirementId);
+    store.dispatch(ActionTypes.FetchRequirement, requirementId).then(() => {
+      loading.value = false;
+    });
     store.dispatch(ActionTypes.FetchProject, projectId);
 
     const alertLogin = (message: string) => {
@@ -355,6 +362,7 @@ export default defineComponent({
       t,
       oidcIsAuthenticated,
       project,
+      loading,
       parentCategory,
       requirement,
       tabItems,
@@ -385,6 +393,10 @@ export default defineComponent({
 
   .title h1 {
     margin: 0;
+  }
+
+  .loading-container {
+    text-align: center;
   }
 
   .lastupdate {


### PR DESCRIPTION
Add progress indicators and some 'no content' messages (e.g., when requirement has no followers, comments, etc.)

Fixes:
- #242