### PR TITLE
Feat: Persistent Locale Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@vuelidate/core": "^2.0.0-alpha.16",
         "@vuelidate/validators": "^2.0.0-alpha.22",
         "dayjs": "^1.10.4",
+        "js-cookie": "^3.0.1",
         "markdown-it": "^12.3.2",
         "oidc-client": "^1.11.5",
         "primeflex": "^2.0.0",
@@ -4757,6 +4758,14 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -10571,6 +10580,11 @@
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vuelidate/core": "^2.0.0-alpha.16",
     "@vuelidate/validators": "^2.0.0-alpha.22",
     "dayjs": "^1.10.4",
+    "js-cookie": "^3.0.1",
     "markdown-it": "^12.3.2",
     "oidc-client": "^1.11.5",
     "primeflex": "^2.0.0",

--- a/src/components/AppTopbar.vue
+++ b/src/components/AppTopbar.vue
@@ -40,6 +40,7 @@ import { computed, defineComponent, watch, getCurrentInstance, ref } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
+import Cookies from 'js-cookie';
 
 import ActivityTracker from './ActivityTracker.vue';
 
@@ -55,7 +56,8 @@ export default defineComponent({
 		const { push } = useRouter();
 
 		watch(locale, (newLocale) => {
-    	app?.appContext.config.globalProperties.$dayjs.locale(newLocale);
+    	  app?.appContext.config.globalProperties.$dayjs.locale(newLocale);
+		  Cookies.set('locale', newLocale);
 		});
 
 		const oidcIsAuthenticated = computed(() => store.getters['oidcStore/oidcIsAuthenticated']);

--- a/src/components/CategoryCard.vue
+++ b/src/components/CategoryCard.vue
@@ -2,6 +2,7 @@
   <Card id="card">
     <template #title>
       <div>{{ name }}</div>
+      <div style="display: none;">{{updateTrigger}}</div>
       <div class="lastupdate p-d-flex p-ai-center" v-if="showCreationDate">
         <span :title="'created ' + $dayjs(creationDate).format('LLL')"><i class="pi pi-plus-circle"></i> created {{ $dayjs(creationDate).fromNow() }}</span>
       </div>
@@ -22,8 +23,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, toRefs } from 'vue'
+import { computed, defineComponent, toRefs, watch, ref } from 'vue'
 import { useI18n } from 'vue-i18n';
+import dayjs from 'dayjs'
 
 import { followersIcon, requirementsIcon } from '../assets/reqbaz-icons.js';
 
@@ -43,8 +45,18 @@ export default defineComponent({
     const { locale, t } = useI18n({ useScope: 'global' });
     const { lastActivity, creationDate, showCreationDate } = toRefs(props);
 
+    /*
+     * NOTE: This is workaround to force Vue to re-render the component when the locale changes.
+     */
+    const updateTrigger = ref(false);
+    watch([locale], () => {
+      console.log('changed');
+      updateTrigger.value = !updateTrigger.value;
+    });
+
     return {
       t,
+      updateTrigger,
       lastActivity,
       creationDate,
       showCreationDate,

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { store } from "./store";
 import { createI18n } from 'vue-i18n'
 import App from './App.vue';
 
+import Cookies from 'js-cookie';
+
 import messages from '@intlify/vite-plugin-vue-i18n/messages';
 
 import VueMarkdownIt from 'vue3-markdown-it';
@@ -64,7 +66,7 @@ import ErrorHandler from './service/ErrorHandler';
 const app = createApp(App);
 const i18n = createI18n({
   legacy: false,
-  locale: 'en',
+  locale: (Cookies.get('locale') ?? 'en'),
   fallbackLocale: 'en',
   messages
 });


### PR DESCRIPTION
### Adds:
- Stores the user's preferred language once selected, so translation settings are kept when reloading the page or visiting Requirements Bazaar again later.
- This change adds a cookie named `locale`, which does not expire.

### Fixes:
- #132 